### PR TITLE
ConfigUpdater: enable DarkMode for dialogs

### DIFF
--- a/src/ConfigUpdater.cpp
+++ b/src/ConfigUpdater.cpp
@@ -48,7 +48,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD  reasonForCall, LPVOID /*lpReserved*
 	}
 	catch (...) { return FALSE; }
 
-    return TRUE;
+	return TRUE;
 }
 
 
@@ -58,28 +58,38 @@ extern "C" __declspec(dllexport) void setInfo(NppData notpadPlusData)
 	commandMenuInit();
 }
 
-extern "C" __declspec(dllexport) const TCHAR * getName()
+extern "C" __declspec(dllexport) const TCHAR* getName()
 {
 	return NPP_PLUGIN_NAME;
 }
 
-extern "C" __declspec(dllexport) FuncItem * getFuncsArray(int *nbF)
+extern "C" __declspec(dllexport) FuncItem* getFuncsArray(int* nbF)
 {
 	*nbF = nbFunc;
 	return funcItem;
 }
 
 
-extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
+extern "C" __declspec(dllexport) void beNotified(SCNotification* notifyCode)
 {
-	switch (notifyCode->nmhdr.code) 
+	switch (notifyCode->nmhdr.code)
 	{
 		case NPPN_SHUTDOWN:
 		{
 			commandMenuCleanUp();
+			break;
 		}
-		break;
-
+		case NPPN_DARKMODECHANGED:
+		{
+			std::vector<HWND> hw_dlgs = { g_hwndAboutDlg, g_hwndCUStatusDlg };
+			for (auto hw : hw_dlgs) {
+				if (hw) {
+					::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfHandleChange), reinterpret_cast<LPARAM>(hw));
+					::SetWindowPos(hw, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar
+				}
+			}
+			break;
+		}
 		default:
 			return;
 	}
@@ -104,6 +114,6 @@ extern "C" __declspec(dllexport) LRESULT messageProc(UINT /*Message*/, WPARAM /*
 #ifdef UNICODE
 extern "C" __declspec(dllexport) BOOL isUnicode()
 {
-    return TRUE;
+	return TRUE;
 }
 #endif //UNICODE

--- a/src/Dialogs/AboutDialog.cpp
+++ b/src/Dialogs/AboutDialog.cpp
@@ -21,6 +21,8 @@
 #include "PluginVersion.h"
 #include "Hyperlinks.h"
 
+HWND g_hwndAboutDlg = nullptr;
+
 #ifdef _WIN64
 #define BITNESS TEXT("(64 bit)")
 #else
@@ -31,19 +33,45 @@
 #pragma warning(disable: 4100)
 INT_PTR CALLBACK abtDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	switch (uMsg) {
-	case WM_INITDIALOG:
-		ConvertStaticToHyperlink(hwndDlg, IDC_GITHUB);
-		ConvertStaticToHyperlink(hwndDlg, IDC_TINYXML2);
-		//ConvertStaticToHyperlink(hwndDlg, IDC_README);
-		//Edit_SetText(GetDlgItem(hwndDlg, IDC_VERSION), TEXT("DoxyIt v") VERSION_TEXT TEXT(" ") VERSION_STAGE TEXT(" ") BITNESS);
-		wchar_t title[256];
-		swprintf_s(title, L"%s v%s %s", L"CollectionInterface", VERSION_WSTR, BITNESS);
-		Edit_SetText(GetDlgItem(hwndDlg, IDC_VERSION), title);
+		case WM_INITDIALOG:
+		{
+			// save HWND
+			g_hwndAboutDlg = hwndDlg;
 
-		if (1) {
-			// Find Center and then position the window:
+			// need to know versions for making darkMode decisions
+			LRESULT versionNpp = ::SendMessage(nppData._nppHandle, NPPM_GETNPPVERSION, 1, 0);	// HIWORD(nppVersion) = major version; LOWORD(nppVersion) = zero-padded minor (so 8|500 will come after 8|410)
+			LRESULT versionDarkDialog = MAKELONG(540, 8);		// requires 8.5.4.0 for NPPM_DARKMODESUBCLASSANDTHEME (NPPM_GETDARKMODECOLORS was 8.4.1, so covered)
 
-			// find App center
+			bool isDM = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
+			if (isDM && (versionNpp >= versionDarkDialog)) {
+				NppDarkMode::Colors myColors = { 0 };
+				if (::SendMessage(nppData._nppHandle, NPPM_GETDARKMODECOLORS, sizeof(NppDarkMode::Colors), reinterpret_cast<LPARAM>(&myColors))) {
+					SetHyperlinkRGB(myColors.linkText);
+				}
+				else {
+					SetHyperlinkRGB(RGB(64, 64, 255));
+				}
+			}
+			else {
+				SetHyperlinkRGB(RGB(0, 0, 192));
+			}
+
+			// Need to set up any controls _before_ running the subclass-and-theme
+			//		(however, the hyperlink fix must come after subclass-and-theme, otherwise hyperlink is undone)
+			wchar_t title[256];
+			swprintf_s(title, L"%s v%s %s", L"CollectionInterface", VERSION_WSTR, BITNESS);
+			Edit_SetText(GetDlgItem(hwndDlg, IDC_VERSION), title);
+
+			// Now do subclass-and-them
+			if (isDM && versionNpp >= versionDarkDialog) {
+				::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndAboutDlg));
+			}
+
+			// then update the hyperlink
+			ConvertStaticToHyperlink(hwndDlg, IDC_GITHUB);
+			ConvertStaticToHyperlink(hwndDlg, IDC_TINYXML2);
+
+			// Finally, Find Center and then position and display the window:
 			RECT rc;
 			HWND hParent = GetParent(hwndDlg);
 			::GetClientRect(hParent, &rc);
@@ -53,33 +81,35 @@ INT_PTR CALLBACK abtDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			center.x = rc.left + w / 2;
 			center.y = rc.top + h / 2;
 			::ClientToScreen(hParent, &center);
-
-			// and position dialog
 			RECT dlgRect;
 			::GetClientRect(hwndDlg, &dlgRect);
 			int x = center.x - (dlgRect.right - dlgRect.left) / 2;
 			int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
 			::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
-		}
 
-		return true;
-	case WM_COMMAND:
-		switch (LOWORD(wParam)) {
-		case IDCANCEL:
-		case IDOK:
-			EndDialog(hwndDlg, 0);
+			return true;
+		}
+		case WM_COMMAND:
+		{
+			switch (LOWORD(wParam)) {
+				case IDCANCEL:
+				case IDOK:
+					EndDialog(hwndDlg, 0);
+					DestroyWindow(hwndDlg);
+					return true;
+				case IDC_GITHUB:
+					ShellExecute(hwndDlg, TEXT("open"), TEXT(VERSION_URL), NULL, NULL, SW_SHOWNORMAL);
+					return true;
+				case IDC_TINYXML2:
+					ShellExecute(hwndDlg, TEXT("open"), TEXT("https://github.com/leethomason/tinyxml2"), NULL, NULL, SW_SHOWNORMAL);
+					return true;
+			}
+		}
+		case WM_DESTROY:
+		{
 			DestroyWindow(hwndDlg);
 			return true;
-			case IDC_GITHUB:
-				ShellExecute(hwndDlg, TEXT("open"), TEXT(VERSION_URL), NULL, NULL, SW_SHOWNORMAL);
-				return true;
-			case IDC_TINYXML2:
-				ShellExecute(hwndDlg, TEXT("open"), TEXT("https://github.com/leethomason/tinyxml2"), NULL, NULL, SW_SHOWNORMAL);
-				return true;
 		}
-	case WM_DESTROY:
-		DestroyWindow(hwndDlg);
-		return true;
 	}
 	return false;
 }

--- a/src/Dialogs/CUStatusDialog.cpp
+++ b/src/Dialogs/CUStatusDialog.cpp
@@ -23,7 +23,7 @@
 std::wstring _editText = L"";
 bool _InterruptFlag = false;
 
-HWND _hwndDlg;
+HWND g_hwndCUStatusDlg;
 
 INT_PTR CALLBACK ciDlgCUStatusProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
 {
@@ -32,28 +32,18 @@ INT_PTR CALLBACK ciDlgCUStatusProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
     case WM_INITDIALOG:
     {
         // save HWND
-        _hwndDlg = hwndDlg;
+        g_hwndCUStatusDlg = hwndDlg;
 
-        // Find Center and then position the window:
+        ////////
+        // need to know versions for making darkMode decisions
+        ////////
+        LRESULT versionNpp = ::SendMessage(nppData._nppHandle, NPPM_GETNPPVERSION, 1, 0);	// HIWORD(nppVersion) = major version; LOWORD(nppVersion) = zero-padded minor (so 8|500 will come after 8|410)
+        LRESULT versionDarkDialog = MAKELONG(540, 8);		// requires 8.5.4.0 for NPPM_DARKMODESUBCLASSANDTHEME (NPPM_GETDARKMODECOLORS was 8.4.1, so covered)
+        bool isDM = (bool)::SendMessage(nppData._nppHandle, NPPM_ISDARKMODEENABLED, 0, 0);
 
-        // find App center
-        RECT rc;
-        HWND hParent = GetParent(hwndDlg);
-        ::GetClientRect(hParent, &rc);
-        POINT center;
-        int w = rc.right - rc.left;
-        int h = rc.bottom - rc.top;
-        center.x = rc.left + w / 2;
-        center.y = rc.top + h / 2;
-        ::ClientToScreen(hParent, &center);
-
-        // and position dialog
-        RECT dlgRect;
-        ::GetClientRect(hwndDlg, &dlgRect);
-        int x = center.x - (dlgRect.right - dlgRect.left) / 2;
-        int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
-        ::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
-
+        ////////
+        // setup all the controls before triggering dark mode
+        ////////
         // not interrupted yet
         _InterruptFlag = false;
 
@@ -63,6 +53,31 @@ INT_PTR CALLBACK ciDlgCUStatusProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
         // add some text
         custatus_ClearText();
         custatus_AppendText(L"--- ConfigUpdater: Starting ---\r\n");
+
+        ////////
+        // trigger darkmode
+        ////////
+        if (isDM && versionNpp >= versionDarkDialog) {
+            ::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(g_hwndCUStatusDlg));
+        }
+
+        ////////
+        // Finally, Find Center and then position and display the window:
+        ////////
+        RECT rc;
+        HWND hParent = GetParent(hwndDlg);
+        ::GetClientRect(hParent, &rc);
+        POINT center;
+        int w = rc.right - rc.left;
+        int h = rc.bottom - rc.top;
+        center.x = rc.left + w / 2;
+        center.y = rc.top + h / 2;
+        ::ClientToScreen(hParent, &center);
+        RECT dlgRect;
+        ::GetClientRect(hwndDlg, &dlgRect);
+        int x = center.x - (dlgRect.right - dlgRect.left) / 2;
+        int y = center.y - (dlgRect.bottom - dlgRect.top) / 2;
+        ::SetWindowPos(hwndDlg, HWND_TOP, x, y, (dlgRect.right - dlgRect.left), (dlgRect.bottom - dlgRect.top), SWP_SHOWWINDOW);
 
         return true;
     }
@@ -89,7 +104,7 @@ INT_PTR CALLBACK ciDlgCUStatusProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 
 void custatus_CloseWindow(void)
 {
-    ::SendMessage(_hwndDlg, WM_DESTROY, 0, 0);
+    ::SendMessage(g_hwndCUStatusDlg, WM_DESTROY, 0, 0);
 }
 
 void custatus_ClearText(void)
@@ -103,7 +118,7 @@ void custatus_AppendText(LPWSTR newText)
     _editText += newText;
 
     // get edit control from dialog
-    HWND hwndOutput = GetDlgItem(_hwndDlg, IDC_CU_STAT_TEXTOUT);
+    HWND hwndOutput = GetDlgItem(g_hwndCUStatusDlg, IDC_CU_STAT_TEXTOUT);
 
     // set the full text
     ::SendMessage(hwndOutput, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_editText.c_str()));
@@ -117,12 +132,12 @@ void custatus_AppendText(LPWSTR newText)
 
 void custatus_SetProgress(DWORD pct)
 {
-    ::SendDlgItemMessage(_hwndDlg, IDC_CU_STAT_PROGRESS1, PBM_SETPOS, pct, 0);
+    ::SendDlgItemMessage(g_hwndCUStatusDlg, IDC_CU_STAT_PROGRESS1, PBM_SETPOS, pct, 0);
 }
 
 void custatus_AddProgress(DWORD pct)
 {
-    ::SendDlgItemMessage(_hwndDlg, IDC_CU_STAT_PROGRESS1, PBM_DELTAPOS, pct, 0);
+    ::SendDlgItemMessage(g_hwndCUStatusDlg, IDC_CU_STAT_PROGRESS1, PBM_DELTAPOS, pct, 0);
 }
 
 bool custatus_GetInterruptFlag(void)

--- a/src/Dialogs/PluginVersion.h
+++ b/src/Dialogs/PluginVersion.h
@@ -18,8 +18,8 @@
 */
 
 #pragma once
-#define VERSION_DIGITALVALUE        2, 0, 1, 0
-#define VERSION_VALUE               "2.0.1\0"
+#define VERSION_DIGITALVALUE        2, 0, 1, 1
+#define VERSION_VALUE               "2.0.1-dev1\0"
 #define VERSION_WSTR                TEXT(VERSION_VALUE)
 #define VERSION_AUTHOR              "Peter C. Jones\0"
 #define VERSION_PLUGIN_DESCRIPTION  "Notepad++ Plugin to Keep Langs/Stylers/Themes Config Files Up-to-Date\0"

--- a/src/NPP_DarkMode.h
+++ b/src/NPP_DarkMode.h
@@ -1,0 +1,140 @@
+/*
+	Copyright (C) 2025  Peter C. Jones <pryrtcode@pryrt.com>
+
+	This file is part of the source code for the CollectionInterface plugin for Notepad++
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+#include <windows.h>
+
+// extracted from https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppDarkMode.h
+namespace NppDarkMode {
+	struct Colors
+	{
+		COLORREF background = 0;
+		COLORREF softerBackground = 0; // ctrl background color
+		COLORREF hotBackground = 0;
+		COLORREF pureBackground = 0;   // dlg background color
+		COLORREF errorBackground = 0;
+		COLORREF text = 0;
+		COLORREF darkerText = 0;
+		COLORREF disabledText = 0;
+		COLORREF linkText = 0;
+		COLORREF edge = 0;
+		COLORREF hotEdge = 0;
+		COLORREF disabledEdge = 0;
+	};
+
+	struct Brushes
+	{
+		HBRUSH background = nullptr;
+		HBRUSH ctrlBackground = nullptr;
+		HBRUSH hotBackground = nullptr;
+		HBRUSH dlgBackground = nullptr;
+		HBRUSH errorBackground = nullptr;
+
+		HBRUSH edgeBrush = nullptr;
+		HBRUSH hotEdgeBrush = nullptr;
+		HBRUSH disabledEdgeBrush = nullptr;
+
+		Brushes(const Colors& colors)
+			: background(::CreateSolidBrush(colors.background))
+			, ctrlBackground(::CreateSolidBrush(colors.softerBackground))
+			, hotBackground(::CreateSolidBrush(colors.hotBackground))
+			, dlgBackground(::CreateSolidBrush(colors.pureBackground))
+			, errorBackground(::CreateSolidBrush(colors.errorBackground))
+
+			, edgeBrush(::CreateSolidBrush(colors.edge))
+			, hotEdgeBrush(::CreateSolidBrush(colors.hotEdge))
+			, disabledEdgeBrush(::CreateSolidBrush(colors.disabledEdge))
+		{
+		}
+
+		~Brushes()
+		{
+			::DeleteObject(background);			background = nullptr;
+			::DeleteObject(ctrlBackground);		ctrlBackground = nullptr;
+			::DeleteObject(hotBackground);		hotBackground = nullptr;
+			::DeleteObject(dlgBackground);		dlgBackground = nullptr;
+			::DeleteObject(errorBackground);	errorBackground = nullptr;
+
+			::DeleteObject(edgeBrush);			edgeBrush = nullptr;
+			::DeleteObject(hotEdgeBrush);		hotEdgeBrush = nullptr;
+			::DeleteObject(disabledEdgeBrush);	disabledEdgeBrush = nullptr;
+		}
+
+		void change(const Colors& colors)
+		{
+			::DeleteObject(background);
+			::DeleteObject(ctrlBackground);
+			::DeleteObject(hotBackground);
+			::DeleteObject(dlgBackground);
+			::DeleteObject(errorBackground);
+
+			::DeleteObject(edgeBrush);
+			::DeleteObject(hotEdgeBrush);
+			::DeleteObject(disabledEdgeBrush);
+
+			background = ::CreateSolidBrush(colors.background);
+			ctrlBackground = ::CreateSolidBrush(colors.softerBackground);
+			hotBackground = ::CreateSolidBrush(colors.hotBackground);
+			dlgBackground = ::CreateSolidBrush(colors.pureBackground);
+			errorBackground = ::CreateSolidBrush(colors.errorBackground);
+
+			edgeBrush = ::CreateSolidBrush(colors.edge);
+			hotEdgeBrush = ::CreateSolidBrush(colors.hotEdge);
+			disabledEdgeBrush = ::CreateSolidBrush(colors.disabledEdge);
+		}
+	};
+
+	struct Pens
+	{
+		HPEN darkerTextPen = nullptr;
+		HPEN edgePen = nullptr;
+		HPEN hotEdgePen = nullptr;
+		HPEN disabledEdgePen = nullptr;
+
+		Pens(const Colors& colors)
+			: darkerTextPen(::CreatePen(PS_SOLID, 1, colors.darkerText))
+			, edgePen(::CreatePen(PS_SOLID, 1, colors.edge))
+			, hotEdgePen(::CreatePen(PS_SOLID, 1, colors.hotEdge))
+			, disabledEdgePen(::CreatePen(PS_SOLID, 1, colors.disabledEdge))
+		{
+		}
+
+		~Pens()
+		{
+			::DeleteObject(darkerTextPen);		darkerTextPen = nullptr;
+			::DeleteObject(edgePen);			edgePen = nullptr;
+			::DeleteObject(hotEdgePen);			hotEdgePen = nullptr;
+			::DeleteObject(disabledEdgePen);	disabledEdgePen = nullptr;
+		}
+
+		void change(const Colors& colors)
+		{
+			::DeleteObject(darkerTextPen);
+			::DeleteObject(edgePen);
+			::DeleteObject(hotEdgePen);
+			::DeleteObject(disabledEdgePen);
+
+			darkerTextPen = ::CreatePen(PS_SOLID, 1, colors.darkerText);
+			edgePen = ::CreatePen(PS_SOLID, 1, colors.edge);
+			hotEdgePen = ::CreatePen(PS_SOLID, 1, colors.hotEdge);
+			disabledEdgePen = ::CreatePen(PS_SOLID, 1, colors.disabledEdge);
+		}
+
+	};
+
+}

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -75,4 +75,17 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 void menucall_UpdateConfigFiles();
 void menucall_AboutDlg();
 
+//
+// Need to expose the globals from PluginDefinition.cpp:
+//
+extern NppData nppData;
+extern FuncItem funcItem[nbFunc];
+
+//
+// My global variables
+//
+
+extern HWND g_hwndAboutDlg;
+extern HWND g_hwndCUStatusDlg;
+
 #endif //PLUGINDEFINITION_H

--- a/src/PluginInterface.h
+++ b/src/PluginInterface.h
@@ -23,6 +23,7 @@
 
 #include "Scintilla.h"
 #include "Notepad_plus_msgs.h"
+#include "NPP_DarkMode.h"
 
 
 typedef const wchar_t * (__cdecl * PFUNCGETNAME)();

--- a/src/lib/Hyperlinks.cpp
+++ b/src/lib/Hyperlinks.cpp
@@ -16,6 +16,9 @@
 #define PROP_STATIC_HYPERLINK	TEXT("_Hyperlink_From_Static_")
 #define PROP_UNDERLINE_FONT		TEXT("_Hyperlink_Underline_Font_")
 
+// ConfigUpdater wants to be able to change the color of the hyperlink, but default to URL-blue
+COLORREF _hyperlink_rgb = RGB(0, 0, 192);
+COLORREF SetHyperlinkRGB(COLORREF rgbNew) { _hyperlink_rgb = rgbNew; return _hyperlink_rgb; }
 
 LRESULT CALLBACK _HyperlinkParentProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -32,7 +35,7 @@ LRESULT CALLBACK _HyperlinkParentProc(HWND hwnd, UINT message, WPARAM wParam, LP
 		if (fHyperlink)
 		{
 			LRESULT lr = CallWindowProc(pfnOrigProc, hwnd, message, wParam, lParam);
-			SetTextColor(hdc, RGB(0, 0, 192));
+			SetTextColor(hdc, _hyperlink_rgb); // CollectionInterface plugin: changed this to configurable
 			return lr;
 		}
 

--- a/src/lib/Hyperlinks.h
+++ b/src/lib/Hyperlinks.h
@@ -11,5 +11,6 @@
 
 BOOL ConvertStaticToHyperlink(HWND hwndCtl);
 BOOL ConvertStaticToHyperlink(HWND hwndParent, UINT uiCtlId);
+COLORREF SetHyperlinkRGB(COLORREF rgbNew); // added by ConfigUpdater plugin
 
 #endif

--- a/vs.proj/ConfigUpdater.vcxproj
+++ b/vs.proj/ConfigUpdater.vcxproj
@@ -43,6 +43,7 @@
     <ClInclude Include="..\src\lib\Hyperlinks.h" />
     <ClInclude Include="..\src\menuCmdID.h" />
     <ClInclude Include="..\src\Notepad_plus_msgs.h" />
+    <ClInclude Include="..\src\NPP_DarkMode.h" />
     <ClInclude Include="..\src\PluginDefinition.h" />
     <ClInclude Include="..\src\PluginInterface.h" />
     <ClInclude Include="..\src\Scintilla.h" />


### PR DESCRIPTION
For NPP v8.5.4-and-newer, dialogs will be in Dark Mode.

(For v8.5.4 ≤ version(NPP) ≤ v8.8.1, ProgressBar will have light background due to lack of subclassing in N++ source code; v8.8.2 will fix that.  To me, it's not super-jarring to have the PB with lighter background; I am willing to live with that, so I won't add my own subclassing for the intermediate versions.)

resolves #7 