### PR TITLE
Add XSD-based validation for XML files

### DIFF
--- a/src/Classes/ConfigUpdaterClass.cpp
+++ b/src/Classes/ConfigUpdaterClass.cpp
@@ -1047,7 +1047,7 @@ bool ConfigUpdater::_updateOneTheme(tinyxml2::XMLDocument* pModelStylerDoc, std:
 
 					// go to the right line
 					if (lnum != -1)
-						::SendMessage(curScintilla, SCI_GOTOLINE, lnum - 1, 0);
+						::SendMessage(curScintilla, SCI_GOTOLINE, static_cast<WPARAM>(lnum - 1), 0);
 
 					// stop looping
 					_doAbort = true;
@@ -1654,7 +1654,7 @@ void ConfigUpdater::_updateLangs(bool isIntermediateSorted)
 
 					// go to the right line
 					if (lnum != -1)
-						::SendMessage(curScintilla, SCI_GOTOLINE, lnum - 1, 0);
+						::SendMessage(curScintilla, SCI_GOTOLINE, static_cast<WPARAM>(lnum - 1), 0);
 
 					// stop looping
 					_doAbort = true;

--- a/src/Classes/ConfigUpdaterClass.h
+++ b/src/Classes/ConfigUpdaterClass.h
@@ -13,6 +13,8 @@
 #include "menuCmdID.h"
 #include "tinyxml2.h"
 #include "CUStatusDialog.h"
+#include <comutil.h>
+
 
 class ConfigUpdater {
 public:
@@ -24,6 +26,12 @@ private:
 	HANDLE _hOutConsoleFile = 0;																				// stores filehandle for plugin console output
 	UINT_PTR _uOutBufferID = 0;																					// stores BufferID for plugin output
 	std::map<std::string, std::string> _mapModelDefaultColors, _mapStylerDefaultColors;							// store default colors from .model. and the active styler
+
+	// xsd contents for Theme/Styler or Langs validation
+	std::wstring _wsThemeValidatorXsdFileName;
+	std::wstring _wsLangsValidatorXsdFileName;
+	void _initThemeValidatorXSD(void);	// set the contents of the _bstr_ThemeValidatorXSD
+	void _initLangsValidatorXSD(void);	// set the contents of the _bstr_LangsValidatorXSD
 
 	// Checks if the plugin-"console" exists, creates it if necessary, activates the right view/index, and returns the handle 
 	HANDLE _consoleCheck();
@@ -59,6 +67,7 @@ private:
 	bool _isAskRestartCancelled = false;																											// Remember whether CANCEL was chosen when asking to restart while looping through themes
 	bool _isAskRestartYes = false;																													// Remember if YES was pressed, so don't ask at end
 	bool _setting_isIntermediateSorted = false;																										// from settings file, whether or not to generate an intermediate "sorted" file, which has no additions/fixes, but is in same order as final file
+	bool _doStopValidationPester = false;																											// set this true to stop pestering the user with validation errors
 
 	bool _is_dir_writable(const std::wstring& path);																								// checks if a given directory is writeable
 	std::wstring _getWritableTempDir(void);																											// gets a reasonable directory for a Temp file

--- a/src/lib/ValidateXML.h
+++ b/src/lib/ValidateXML.h
@@ -2,7 +2,11 @@
 #include <string>
 #include <comutil.h>
 #include <comdef.h>
+#pragma warning(push)
+#pragma warning(disable: 4192)
+// import DLL without ISequentialStream/_FILETIME exclusion warnings
 #import <msxml6.dll>
+#pragma warning(pop)
 
 // uses MSXML6 to validate XML based on XSD
 namespace ValidateXML {

--- a/src/lib/ValidateXML.h
+++ b/src/lib/ValidateXML.h
@@ -1,0 +1,162 @@
+#pragma once
+#include <string>
+#include <comutil.h>
+#include <comdef.h>
+#import <msxml6.dll>
+
+// uses MSXML6 to validate XML based on XSD
+namespace ValidateXML {
+
+  // delete null characters from padded strings				// private function (invisible to outside world)
+	void _delNull(std::wstring& str)
+	{
+		const auto pos = str.find(L'\0');
+		if (pos != std::wstring::npos) {
+			str.erase(pos);
+		}
+	};
+	void _delNull(std::string& str)
+	{
+		const auto pos = str.find('\0');
+		if (pos != std::string::npos) {
+			str.erase(pos);
+		}
+	};
+
+	// convert wstring to UTF8-encoded bytes in std::string		// private function (invisible to outside world)
+	std::string _wstring_to_utf8(std::wstring& wstr)
+	{
+		if (wstr.empty()) return std::string();
+		int szNeeded = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), static_cast<int>(wstr.size()), NULL, 0, NULL, NULL);
+		if (szNeeded == 0) return std::string();
+		std::string str(szNeeded, '\0');
+		int result = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), static_cast<int>(wstr.size()), const_cast<LPSTR>(str.data()), szNeeded, NULL, NULL);
+		if (result == 0) return std::string();
+		if (result < szNeeded) _delNull(str);
+		return str;
+	}
+
+	// convert UTF8-encoded bytes in std::string to wstring		// private function (invisible to outside world)
+	std::wstring _utf8_to_wstring(std::string& str)
+	{
+		if (str.empty()) return std::wstring();
+		int szNeeded = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), static_cast<int>(str.size()), NULL, 0);
+		if (szNeeded == 0) return std::wstring();
+		std::wstring wstr(szNeeded, L'\0');
+		int result = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), static_cast<int>(str.size()), const_cast<LPWSTR>(wstr.data()), szNeeded);
+		if (result == 0) return std::wstring();
+		if (result < szNeeded) _delNull(wstr);
+		return wstr;
+	}
+
+
+	std::wstring _ws_validation_message;
+	UINT64 _err_line_num;
+	bool _setstatus_validation_failed(std::wstring wsPrefix, HRESULT hr)
+	{
+		_ws_validation_message = wsPrefix + L": COM HRESULT#" + std::to_wstring(hr);
+		_err_line_num = static_cast<UINT64>(-1);
+		return false;
+	}
+	bool _setstatus_validation_failed(std::wstring wsPrefix, std::wstring wsDetails, UINT64 errLineNum = -1)
+	{
+		_ws_validation_message = wsPrefix + L": " + wsDetails;
+		_err_line_num = errLineNum;
+		return false;
+	}
+	bool _setstatus_validation_failed(std::wstring wsPrefix, std::string sDetails, UINT64 errLineNum = -1)
+	{
+		return _setstatus_validation_failed(wsPrefix, _utf8_to_wstring(sDetails), errLineNum);
+	}
+	bool _setstatus_validation_passed(std::wstring wsMessage)
+	{
+		_ws_validation_message = wsMessage;
+		_err_line_num = static_cast<UINT64>(-1);
+		return true;
+	}
+
+	// get the results in various varieties of strings
+	std::wstring wsGetValidationMessage(void) { return _ws_validation_message; }
+	std::string sGetValidationMessage(void) { return _wstring_to_utf8(_ws_validation_message); }
+	UINT64 uGetValidationLineNum(void) { return _err_line_num; }
+
+	// on successful validation, set _ws_validation_message=L"OK" and return true
+	// on validation fail, set _ws_validation_message as appropriate and return false
+	bool validate_xml(std::wstring wsXmlFileName, std::wstring wsXsdFileName)
+	{
+		_err_line_num = static_cast<UINT64>(-1);								// by default, no specific line number
+		bool ret = false;
+		HRESULT hr = CoInitialize(NULL);
+		if (FAILED(hr)) {
+			ret = _setstatus_validation_failed(L"CoInitialize failed", hr);
+			goto ValidationCleanUp;
+		}
+
+		try {
+			// Create the XML DOM document		:: Don't populate it yet; need to have schema prepared first
+			MSXML2::IXMLDOMDocument2Ptr xmlDoc;
+			hr = xmlDoc.CreateInstance(__uuidof(MSXML2::DOMDocument60));
+			if (FAILED(hr)) {
+				ret = _setstatus_validation_failed(L"Failed to create XML DOM document", hr);
+				goto ValidationCleanUp;
+			}
+
+			////////
+			// Prepare the schema, so that when I load contents of XML, it can validate-on-load
+			//		(thus hopefully keeping line number information)
+			////////
+
+			// Create the XML schema cache
+			MSXML2::IXMLDOMSchemaCollectionPtr schemaCache;
+			hr = schemaCache.CreateInstance(__uuidof(MSXML2::XMLSchemaCache60));
+			if (FAILED(hr)) {
+				ret = _setstatus_validation_failed(L"Failed to create XML schema cache", hr);
+				goto ValidationCleanUp;
+			}
+
+			// Add the XSD schema to the cache
+			_bstr_t xsdFile = wsXsdFileName.c_str(); // L"input.xsd";
+			schemaCache->add(L"", xsdFile);
+
+			// Associate the schema cache with the XML document
+			//      many online examples show xmlDoc->schemas = schemaCache; -- which gave me error.
+			//      but old MSDN example <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms762787(v=vs.85)> showed using the method, which works
+			xmlDoc->schemas = schemaCache.GetInterfacePtr();
+
+
+			// Set async to false to ensure loading is synchronous; validateOnParse=true will allow errors when ->load() is called
+			xmlDoc->async = VARIANT_FALSE;
+			xmlDoc->validateOnParse = VARIANT_TRUE;
+			xmlDoc->resolveExternals = VARIANT_TRUE;
+
+			////////
+			// Load the XML file and simultaneously validate due to the options set above
+			////////
+
+			// Load the XML file
+			_bstr_t xmlFile = wsXmlFileName.c_str();
+			VARIANT_BOOL isLoaded = xmlDoc->load(xmlFile);
+
+			// check validation
+			MSXML2::IXMLDOMParseErrorPtr validationError = xmlDoc->parseError;
+			if ((isLoaded != VARIANT_TRUE) || (validationError->errorCode != 0)) {
+				std::string msg = std::string(validationError->reason) + "\nLine#" + std::to_string(validationError->line) + ":\n" + std::string(validationError->srcText);
+				ret = _setstatus_validation_failed(L"XML validation FAILED", msg, static_cast<UINT64>(validationError->line));
+				goto ValidationCleanUp;
+			}
+			else {
+				ret = _setstatus_validation_passed(L"XML validation PASSED.");
+				goto ValidationCleanUp;
+			}
+		}
+		catch (_com_error& e) {
+			ret = _setstatus_validation_failed(L"COM error", e.ErrorMessage());
+			goto ValidationCleanUp;
+		}
+
+	ValidationCleanUp:
+		CoUninitialize();
+		return ret;
+	}
+
+}

--- a/vs.proj/ConfigUpdater.vcxproj
+++ b/vs.proj/ConfigUpdater.vcxproj
@@ -41,6 +41,7 @@
     <ClInclude Include="..\src\DockingFeature\Window.h" />
     <ClInclude Include="..\src\lib\tinyxml2.h" />
     <ClInclude Include="..\src\lib\Hyperlinks.h" />
+    <ClInclude Include="..\src\lib\ValidateXML.h" />
     <ClInclude Include="..\src\menuCmdID.h" />
     <ClInclude Include="..\src\Notepad_plus_msgs.h" />
     <ClInclude Include="..\src\NPP_DarkMode.h" />
@@ -167,7 +168,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -183,7 +184,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -199,7 +200,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -218,7 +219,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -242,7 +243,7 @@ copy ..\README.md ..\bin\README.md</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
@@ -266,7 +267,7 @@ copy ..\README.md ..\bin64\README.md</Command>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;pathcch.lib;msxml6.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(TargetName).lib</ImportLibrary>
     </Link>
     <PostBuildEvent>


### PR DESCRIPTION
Validate the langs.xml, stylers.xml, and themes\*.xml after they are updated.

resolves #1