### PR TITLE
Consolidate repeated code

### DIFF
--- a/src/Classes/ConfigDownloaderClass.h
+++ b/src/Classes/ConfigDownloaderClass.h
@@ -23,7 +23,6 @@ public:
 	bool go(void);
 
 private:
-	NppData* pNppData;
 	struct {
 		std::wstring
 			AppDir,				// path for the application's directory
@@ -36,7 +35,6 @@ private:
 			StylersModel;		// URL for the most recent stylers.model.xml
 	} _wsURL;
 
-	bool ConfigDownloader::_is_dir_writable(const std::wstring& path);
 	std::wstring getWritableTempDir(void);
 	bool downloadFileToDisk(const std::wstring& url, const std::wstring& path);
 	bool ask_overwrite_if_exists(const std::wstring& path);

--- a/src/Classes/ConfigUpdaterClass.h
+++ b/src/Classes/ConfigUpdaterClass.h
@@ -10,6 +10,7 @@
 #include <pathcch.h>
 #include <shlwapi.h>
 #include "PluginDefinition.h"
+#include "NppMetaClass.h"
 #include "menuCmdID.h"
 #include "tinyxml2.h"
 #include "CUStatusDialog.h"
@@ -74,7 +75,6 @@ private:
 	bool _setting_isIntermediateSorted = false;																										// from settings file, whether or not to generate an intermediate "sorted" file, which has no additions/fixes, but is in same order as final file
 	bool _doStopValidationPester = false;																											// set this true to stop pestering the user with validation errors
 
-	bool _is_dir_writable(const std::wstring& path);																								// checks if a given directory is writeable
 	std::wstring _getWritableTempDir(void);																											// gets a reasonable directory for a Temp file
 	bool _ask_dir_permissions(const std::wstring& path);																							// tests if writable, and asks for UAC if not
 	bool _ask_rerun_normal(void);																													// tests if Admin, and asks to restart normally; if not, asks if you want to restart to have it take effect
@@ -103,7 +103,7 @@ private:
 			}
 			::MessageBoxA(NULL, sMsg.c_str(), "XML Error", MB_ICONWARNING | MB_OK);
 			if (p_doc!=NULL && p_doc->ErrorLineNum() && wsFilePath.size()) {
-				if (::SendMessage(_hwndNPP, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(wsFilePath.c_str()))) {
+				if (::SendMessage(gNppMetaInfo.hwnd._nppHandle, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(wsFilePath.c_str()))) {
 					extern NppData nppData;	// not in PluginDefinition.h
 
 					// Get the current scintilla
@@ -128,25 +128,5 @@ private:
 		}
 		return false;
 	};
-
-	////////////////////////////////
-	// Npp Metadata
-	////////////////////////////////
-
-	void _populateNppDirs(void);
-	std::wstring _askSettingsDir(void);
-	std::wstring
-		_nppAppDir,
-		_nppAppThemesDir,
-		_nppExePath,
-		_nppCfgDir,
-		_nppCfgPluginConfigDir,
-		_nppCfgPluginConfigMyDir,
-		_nppCfgUdlDir,
-		_nppCfgFunctionListDir,
-		_nppCfgAutoCompletionDir,
-		_nppCfgThemesDir;
-
-	HWND _hwndNPP;
 };
 

--- a/src/Classes/ConfigValidatorClass.cpp
+++ b/src/Classes/ConfigValidatorClass.cpp
@@ -1,158 +1,25 @@
 #include "ConfigValidatorClass.h"
 #include "ValidateXML.h"
 #include "PopulateXSD.h"
+#include "NppMetaClass.h"
 
-
-ConfigValidator::ConfigValidator(NppData& origNppData)
+ConfigValidator::ConfigValidator(NppData& /*origNppData*/)
 {
-	_populateNppMetadata(origNppData);
+	gNppMetaInfo.populate();
 	_populateValidationLists();
-}
-
-void ConfigValidator::_populateNppMetadata(NppData& origNppData)
-{
-	_npp.hwnd = origNppData;
-
-	////////////////////////////////
-	// Get the directory which stores the executable
-	////////////////////////////////
-	std::wstring exeDir(MAX_PATH, '\0');
-	::SendMessage(_npp.hwnd._nppHandle, NPPM_GETNPPDIRECTORY, MAX_PATH, reinterpret_cast<LPARAM>(exeDir.data()));
-	_delNull(exeDir);
-	// and the excecutable file path (including `\notepad++.exe`)
-	std::wstring exePath(MAX_PATH, '\0');
-	LRESULT szExe = ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETNPPFULLFILEPATH, 0, reinterpret_cast<LPARAM>(exePath.data()));
-	if (szExe) {
-		_delNull(exePath);
-		_npp.dir.appExePath = exePath;
-	}
-
-	////////////////////////////////
-	// Get the AppData or Portable folders, as being relative to the plugins/Config directory
-	////////////////////////////////
-
-	// %AppData%\Notepad++\Plugins\Config or equiv
-	LRESULT sz = 1 + ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETPLUGINSCONFIGDIR, 0, NULL);
-	std::wstring pluginCfgDir(sz, '\0');
-	::SendMessage(_npp.hwnd._nppHandle, NPPM_GETPLUGINSCONFIGDIR, sz, reinterpret_cast<LPARAM>(pluginCfgDir.data()));
-	_delNull(pluginCfgDir);
-	_npp.dir.cfgPluginConfig = pluginCfgDir;
-	_npp.dir.cfgPluginConfigMyDir = pluginCfgDir + L"\\ConfigUpdater";
-
-	// %AppData%\Notepad++\Plugins or equiv
-	//		since it's removing the tail, it will never be longer than pluginCfgDir; since it's in-place, initialize with the first
-	std::wstring pluginDir = pluginCfgDir;
-	PathCchRemoveFileSpec(const_cast<PWSTR>(pluginDir.data()), pluginCfgDir.size());
-	_delNull(pluginDir);
-
-	// %AppData%\Notepad++ or equiv is what I'm really looking for
-	// _nppCfgDir				#py# _nppConfigDirectory = os.path.dirname(os.path.dirname(notepad.getPluginConfigDir()))
-	_npp.dir.cfg = pluginDir;
-	PathCchRemoveFileSpec(const_cast<PWSTR>(_npp.dir.cfg.data()), pluginDir.size());
-	_delNull(_npp.dir.cfg);
-
-	// Save this version, because Cloud/SettingsDir will overwrite _npp.dir.cfg, but I will still need to be able to fall back to the AppData||Portable
-	std::wstring appDataOrPortableDir = _npp.dir.cfg;
-
-	////////////////////////////////
-	// Check for cloud and -settingsDir config-override locations
-	////////////////////////////////
-	bool usesCloud = false;
-	sz = ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETSETTINGSONCLOUDPATH, 0, 0); // get number of wchars in settings-on-cloud path (0 means settings-on-cloud is disabled)
-	if (sz) {
-		usesCloud = true;
-		std::wstring wsCloudDir(sz + 1, '\0');
-		LRESULT szGot = ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETSETTINGSONCLOUDPATH, sz + 1, reinterpret_cast<LPARAM>(wsCloudDir.data()));
-		if (szGot == sz) {
-			_delNull(wsCloudDir);
-			_npp.dir.cfg = wsCloudDir;
-		}
-	}
-
-	// -settingsDir: if command-line option is enabled, use that directory for some config files
-	bool usesSettingsDir = false;
-	std::wstring wsSettingsDir = _askSettingsDir();
-	if (wsSettingsDir.length() > 0)
-	{
-		usesSettingsDir = true;
-		_npp.dir.cfg = wsSettingsDir;
-	}
-
-	////////////////////////////////
-	// Now that we've got all the info, decide on final locations for Function List, UDL, and Themes;
-	// AutoCompletion is always relative to executable directory
-	////////////////////////////////
-
-
-	// FunctionList: must be AppData or PortableDir, because FL does NOT work in Cloud or Settings directory
-	// _nppCfgFunctionListDir	#py# _nppCfgFunctionListDirectory = os.path.join(_nppConfigDirectory, 'functionList')
-	_npp.dir.cfgFunctionList = appDataOrPortableDir + L"\\functionList";
-
-	// UDL: follows SettingsDir >> Cloud Dir >> Portable >> AppData
-	// _nppCfgUdlDir			#py# _nppCfgUdlDirectory = os.path.join(_nppConfigDirectory, 'userDefineLangs')
-	_npp.dir.cfgUdl = _npp.dir.cfg + L"\\userDefineLangs";
-
-	// THEMES: does NOT follow SettingsDir (might be a N++ bug, but must live with what IS, not what SHOULD BE); DOES follow Cloud Dir >> Portable >> AppData
-	// _nppCfgThemesDir			#py# _nppCfgThemesDirectory = os.path.join(_nppConfigDirectory, 'themes')
-	_npp.dir.cfgThemes = (usesSettingsDir ? appDataOrPortableDir : _npp.dir.cfg) + L"\\themes";
-
-	// AutoCompletion is _always_ relative to notepad++.exe, never in AppData or CloudConfig or SettingsDir
-	// _nppCfgAutoCompletionDir	#py# _nppAppAutoCompletionDirectory = os.path.join(notepad.getNppDir(), 'autoCompletion')
-	_npp.dir.cfgAutoCompletion = exeDir + L"\\autoCompletion";
-
-	// also, want to save the app directory and the themes relative to the app (because themes can be found in _both_ locations)
-	_npp.dir.app = exeDir;
-	_npp.dir.appThemes  = _npp.dir.app + L"\\themes";
-
-	return;
-}
-
-// Parse the -settingsDir out of the current command line
-//	FUTURE: if a future version of N++ includes PR#16946, then do an "if version>vmin, use new message" section in the code
-std::wstring ConfigValidator::_askSettingsDir(void)
-{
-	LRESULT sz = ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETCURRENTCMDLINE, 0, 0);
-	if (!sz) return L"";
-	std::wstring strCmdLine(sz + 1, L'\0');
-	LRESULT got = ::SendMessage(_npp.hwnd._nppHandle, NPPM_GETCURRENTCMDLINE, sz + 1, reinterpret_cast<LPARAM>(strCmdLine.data()));
-	if (got != sz) return L"";
-	_delNull(strCmdLine);
-
-	std::wstring wsSettingsDir = L"";
-	size_t p = 0;
-	if ((p = strCmdLine.find(L"-settingsDir=")) != std::wstring::npos) {
-		std::wstring wsEnd = L" ";
-		// start by grabbing from after the = to the end of the string
-		wsSettingsDir = strCmdLine.substr(p + 13, strCmdLine.length() - p - 13);
-		if (wsSettingsDir[0] == L'"') {
-			wsSettingsDir = wsSettingsDir.substr(1, wsSettingsDir.length() - 1);
-			wsEnd = L"\"";
-		}
-		p = wsSettingsDir.find(wsEnd);
-		if (p != std::wstring::npos) {
-			// found the ending space or quote, so do everything _before_ that (need last position=p-1, which means a count of p)
-			wsSettingsDir = wsSettingsDir.substr(0, p);
-		}
-		else if (wsEnd == L"\"") {
-			// could not find end quote; should probably throw an error or something, but for now, just pretend I found nothing...
-			return L"";
-		}	// none found and looking for space means it found end-of-string, which is fine with the space separator
-	}
-
-	return wsSettingsDir;
 }
 
 // create the list/mapping of XML and XSD
 void ConfigValidator::_populateValidationLists(void)
 {
 	// start with stylers/themes XSD
-	std::wstring xpath = _npp.dir.cfgPluginConfigMyDir + L"\\theme.xsd";
+	std::wstring xpath = gNppMetaInfo.dir.cfgPluginConfigMyDir + L"\\theme.xsd";
 	if (!PathFileExists(xpath.c_str()))
 		PopulateXSD::WriteThemeXSD(xpath);
 
 	// work on stylers/themes XML
 	std::wstring fname = L"stylers.xml";
-	std::wstring fpath = _npp.dir.cfg + L"\\" + fname;
+	std::wstring fpath = gNppMetaInfo.dir.cfg + L"\\" + fname;
 	if (PathFileExists(fpath.c_str())) {
 		_xmlNames.push_back(fname);
 		_xmlPaths.push_back(fpath);
@@ -160,8 +27,8 @@ void ConfigValidator::_populateValidationLists(void)
 	}
 
 	// determine whether to use just cfg or also use app
-	std::vector<std::wstring> themeDirs{ _npp.dir.cfgThemes, _npp.dir.appThemes };
-	if (_npp.dir.cfgThemes == _npp.dir.appThemes)
+	std::vector<std::wstring> themeDirs{ gNppMetaInfo.dir.cfgThemes, gNppMetaInfo.dir.appThemes };
+	if (gNppMetaInfo.dir.cfgThemes == gNppMetaInfo.dir.appThemes)
 		themeDirs.pop_back();
 
 	// need to change directory to iterate the directory, so keep track of where I was before
@@ -198,11 +65,11 @@ void ConfigValidator::_populateValidationLists(void)
 	}
 
 	// finally, langs.xml using langs.xsd
-	xpath = _npp.dir.cfgPluginConfigMyDir + L"\\langs.xsd";
+	xpath = gNppMetaInfo.dir.cfgPluginConfigMyDir + L"\\langs.xsd";
 	if (!PathFileExists(xpath.c_str()))
 		PopulateXSD::WriteLangsXSD(xpath);
 	fname = L"langs.xml";
-	fpath = _npp.dir.cfg + L"\\" + fname;
+	fpath = gNppMetaInfo.dir.cfg + L"\\" + fname;
 	if (PathFileExists(fpath.c_str())) {
 		_xmlNames.push_back(fname);
 		_xmlPaths.push_back(fpath);
@@ -210,16 +77,6 @@ void ConfigValidator::_populateValidationLists(void)
 	}
 
 }
-
-// delete null characters from padded wstrings				// private function (invisible to outside world)
-std::wstring ConfigValidator::_delNull(std::wstring& str)
-{
-	const auto pos = str.find(L'\0');
-	if (pos != std::wstring::npos) {
-		str.erase(pos);
-	}
-	return str;
-};
 
 // get the active scintilla handle
 HWND ConfigValidator::_hwActiveScintilla(void)
@@ -233,15 +90,15 @@ HWND ConfigValidator::_hwActiveScintilla(void)
 // retrieve one of the directories
 std::wstring ConfigValidator::getNppDir(std::wstring wsWhichDir)
 {
-	if (wsWhichDir == L"app") return _npp.dir.app;
-	if (wsWhichDir == L"appExe") return _npp.dir.appExePath;
-	if (wsWhichDir == L"appThemes") return _npp.dir.appThemes;
-	if (wsWhichDir == L"cfg") return _npp.dir.cfg;
-	if (wsWhichDir == L"cfgAutoCompletion") return _npp.dir.cfgAutoCompletion;
-	if (wsWhichDir == L"cfgFunctionList") return _npp.dir.cfgFunctionList;
-	if (wsWhichDir == L"cfgPluginConfig") return _npp.dir.cfgPluginConfig;
-	if (wsWhichDir == L"cfgPluginConfigMyDir") return _npp.dir.cfgPluginConfigMyDir;
-	if (wsWhichDir == L"cfgThemes") return _npp.dir.cfgThemes;
-	if (wsWhichDir == L"cfgUdl") return _npp.dir.cfgUdl;
+	if (wsWhichDir == L"app") return gNppMetaInfo.dir.app;
+	if (wsWhichDir == L"appExe") return gNppMetaInfo.dir.appExePath;
+	if (wsWhichDir == L"appThemes") return gNppMetaInfo.dir.appThemes;
+	if (wsWhichDir == L"cfg") return gNppMetaInfo.dir.cfg;
+	if (wsWhichDir == L"cfgAutoCompletion") return gNppMetaInfo.dir.cfgAutoCompletion;
+	if (wsWhichDir == L"cfgFunctionList") return gNppMetaInfo.dir.cfgFunctionList;
+	if (wsWhichDir == L"cfgPluginConfig") return gNppMetaInfo.dir.cfgPluginConfig;
+	if (wsWhichDir == L"cfgPluginConfigMyDir") return gNppMetaInfo.dir.cfgPluginConfigMyDir;
+	if (wsWhichDir == L"cfgThemes") return gNppMetaInfo.dir.cfgThemes;
+	if (wsWhichDir == L"cfgUdl") return gNppMetaInfo.dir.cfgUdl;
 	return L"";
 }

--- a/src/Classes/ConfigValidatorClass.h
+++ b/src/Classes/ConfigValidatorClass.h
@@ -10,6 +10,7 @@
 #include "PluginDefinition.h"
 #include "menuCmdID.h"
 #include "CUValidationDialog.h"
+#include "NppMetaClass.h"
 
 class ConfigValidator {
 public:
@@ -20,7 +21,7 @@ public:
 	std::vector<std::wstring>& getXmlNames(void) { return _xmlNames; };	// retrieve the XML Names vector
 	std::vector<std::wstring>& getXmlPaths(void) { return _xmlPaths; };	// retrieve the XML Paths vector
 	std::vector<std::wstring>& getXsdPaths(void) { return _xsdPaths; };	// retrieve the XSD Paths vector
-	HWND getNppHwnd(void) { return _npp.hwnd._nppHandle; }				// retrieve the NPP HWND
+	HWND getNppHwnd(void) { return gNppMetaInfo.hwnd._nppHandle; }				// retrieve the NPP HWND
 	HWND getActiveScintilla(void) { return _hwActiveScintilla(); }		// retrieve the Active Scintilla HWND
 	std::wstring getNppDir(std::wstring wsWhichDir);					// retrieve one of the directories
 
@@ -40,32 +41,7 @@ private:
 	// Private Helpers
 	////////////////////////////////
 
-	// delete NULL characters at end of wstring
-	std::wstring _delNull(std::wstring& str);
-
 	// get the active scintilla handle
 	HWND _hwActiveScintilla(void);
-
-	////////////////////////////////
-	// Npp Metadata
-	////////////////////////////////
-	void _populateNppMetadata(NppData& origNppData);	// using the HWND information, poll N++ for the correct directory information and other metadata
-	std::wstring _askSettingsDir(void);					// contains all the logic and calls to get the -settingsDir from N++ (since there isn't an easy message)
-	struct {
-		NppData hwnd;
-		struct {
-			std::wstring
-				app,
-				appThemes,
-				appExePath,
-				cfg,
-				cfgPluginConfig,
-				cfgPluginConfigMyDir,
-				cfgUdl,
-				cfgFunctionList,
-				cfgAutoCompletion,
-				cfgThemes;
-		} dir;
-	} _npp;
 
 };

--- a/src/Classes/NppMetaClass.cpp
+++ b/src/Classes/NppMetaClass.cpp
@@ -1,0 +1,150 @@
+#include "NppMetaClass.h"
+#include <pathcch.h>
+#include <shlwapi.h>
+
+// Global NppMetaInfo object
+NppMetaInfo gNppMetaInfo;
+
+NppMetaInfo::NppMetaInfo(void)
+	: hwnd(nppData)
+{
+	_isInitialized = false;
+	dir = { L"", L"", L"", L"", L"", L"", L"", L"", L"", L"", L"" };
+	return;
+}
+
+// Run this in the constructor for any class that uses it
+// (internally tracks whether it's been populated already, and doesn't duplicate effort)
+void NppMetaInfo::populate(void)
+{
+	if (_isInitialized) return;
+
+	////////////////////////////////
+	// Get the directory which stores the executable
+	////////////////////////////////
+	std::wstring exeDir(MAX_PATH, '\0');
+	::SendMessage(hwnd._nppHandle, NPPM_GETNPPDIRECTORY, MAX_PATH, reinterpret_cast<LPARAM>(exeDir.data()));
+	pcjHelper::delNull(exeDir);
+	// and the excecutable file path (including `\notepad++.exe`)
+	std::wstring exePath(MAX_PATH, '\0');
+	LRESULT szExe = ::SendMessage(hwnd._nppHandle, NPPM_GETNPPFULLFILEPATH, 0, reinterpret_cast<LPARAM>(exePath.data()));
+	if (szExe) {
+		pcjHelper::delNull(exePath);
+		dir.appExePath = exePath;
+	}
+
+	////////////////////////////////
+	// Get the AppData or Portable folders, as being relative to the plugins/Config directory
+	////////////////////////////////
+
+	// %AppData%\Notepad++\Plugins\Config or equiv
+	LRESULT sz = 1 + ::SendMessage(hwnd._nppHandle, NPPM_GETPLUGINSCONFIGDIR, 0, NULL);
+	std::wstring pluginCfgDir(sz, '\0');
+	::SendMessage(hwnd._nppHandle, NPPM_GETPLUGINSCONFIGDIR, sz, reinterpret_cast<LPARAM>(pluginCfgDir.data()));
+	pcjHelper::delNull(pluginCfgDir);
+	dir.cfgPluginConfig = pluginCfgDir;
+	dir.cfgPluginConfigMyDir = pluginCfgDir + L"\\ConfigUpdater";
+
+	// %AppData%\Notepad++\Plugins or equiv
+	//		since it's removing the tail, it will never be longer than pluginCfgDir; since it's in-place, initialize with the first
+	std::wstring pluginDir = pluginCfgDir;
+	PathCchRemoveFileSpec(const_cast<PWSTR>(pluginDir.data()), pluginCfgDir.size());
+	pcjHelper::delNull(pluginDir);
+
+	// %AppData%\Notepad++ or equiv is what I'm really looking for
+	// _nppCfgDir				#py# _nppConfigDirectory = os.path.dirname(os.path.dirname(notepad.getPluginConfigDir()))
+	dir.cfg = pluginDir;
+	PathCchRemoveFileSpec(const_cast<PWSTR>(dir.cfg.data()), pluginDir.size());
+	pcjHelper::delNull(dir.cfg);
+
+	// Save this version, because Cloud/SettingsDir will overwrite _npp.dir.cfg, but I will still need to be able to fall back to the AppData||Portable
+	dir.appDataEquiv = dir.cfg;
+
+	////////////////////////////////
+	// Check for cloud and -settingsDir config-override locations
+	////////////////////////////////
+	bool usesCloud = false;
+	sz = ::SendMessage(hwnd._nppHandle, NPPM_GETSETTINGSONCLOUDPATH, 0, 0); // get number of wchars in settings-on-cloud path (0 means settings-on-cloud is disabled)
+	if (sz) {
+		usesCloud = true;
+		std::wstring wsCloudDir(sz + 1, '\0');
+		LRESULT szGot = ::SendMessage(hwnd._nppHandle, NPPM_GETSETTINGSONCLOUDPATH, sz + 1, reinterpret_cast<LPARAM>(wsCloudDir.data()));
+		if (szGot == sz) {
+			pcjHelper::delNull(wsCloudDir);
+			dir.cfg = wsCloudDir;
+		}
+	}
+
+	// -settingsDir: if command-line option is enabled, use that directory for some config files
+	bool usesSettingsDir = false;
+	std::wstring wsSettingsDir = _askSettingsDir();
+	if (wsSettingsDir.length() > 0)
+	{
+		usesSettingsDir = true;
+		dir.cfg = wsSettingsDir;
+	}
+
+	////////////////////////////////
+	// Now that we've got all the info, decide on final locations for Function List, UDL, and Themes;
+	// AutoCompletion is always relative to executable directory
+	////////////////////////////////
+
+	// FunctionList: must be AppData or PortableDir, because FL does NOT work in Cloud or Settings directory
+	// _nppCfgFunctionListDir	#py# _nppCfgFunctionListDirectory = os.path.join(_nppConfigDirectory, 'functionList')
+	dir.cfgFunctionList = dir.appDataEquiv + L"\\functionList";
+
+	// UDL: follows SettingsDir >> Cloud Dir >> Portable >> AppData
+	// _nppCfgUdlDir			#py# _nppCfgUdlDirectory = os.path.join(_nppConfigDirectory, 'userDefineLangs')
+	dir.cfgUdl = dir.cfg + L"\\userDefineLangs";
+
+	// THEMES: does NOT follow SettingsDir (might be a N++ bug, but must live with what IS, not what SHOULD BE); DOES follow Cloud Dir >> Portable >> AppData
+	// _nppCfgThemesDir			#py# _nppCfgThemesDirectory = os.path.join(_nppConfigDirectory, 'themes')
+	dir.cfgThemes = (usesSettingsDir ? dir.appDataEquiv : dir.cfg) + L"\\themes";
+
+	// AutoCompletion is _always_ relative to notepad++.exe, never in AppData or CloudConfig or SettingsDir
+	// _nppCfgAutoCompletionDir	#py# _nppAppAutoCompletionDirectory = os.path.join(notepad.getNppDir(), 'autoCompletion')
+	dir.cfgAutoCompletion = exeDir + L"\\autoCompletion";
+
+	// also, want to save the app directory and the themes relative to the app (because themes can be found in _both_ locations)
+	dir.app = exeDir;
+	dir.appThemes = dir.app + L"\\themes";
+
+	// Done with populate(), so safe to call it initialized
+	_isInitialized = true;
+	return;
+}
+
+// Parse the -settingsDir out of the current command line
+//	FUTURE: if a future version of N++ includes PR#16946, then do an "if version>vmin, use new message" section in the code
+std::wstring NppMetaInfo::_askSettingsDir(void)
+{
+	LRESULT sz = ::SendMessage(hwnd._nppHandle, NPPM_GETCURRENTCMDLINE, 0, 0);
+	if (!sz) return L"";
+	std::wstring strCmdLine(sz + 1, L'\0');
+	LRESULT got = ::SendMessage(hwnd._nppHandle, NPPM_GETCURRENTCMDLINE, sz + 1, reinterpret_cast<LPARAM>(strCmdLine.data()));
+	if (got != sz) return L"";
+	pcjHelper::delNull(strCmdLine);
+
+	std::wstring wsSettingsDir = L"";
+	size_t p = 0;
+	if ((p = strCmdLine.find(L"-settingsDir=")) != std::wstring::npos) {
+		std::wstring wsEnd = L" ";
+		// start by grabbing from after the = to the end of the string
+		wsSettingsDir = strCmdLine.substr(p + 13, strCmdLine.length() - p - 13);
+		if (wsSettingsDir[0] == L'"') {
+			wsSettingsDir = wsSettingsDir.substr(1, wsSettingsDir.length() - 1);
+			wsEnd = L"\"";
+		}
+		p = wsSettingsDir.find(wsEnd);
+		if (p != std::wstring::npos) {
+			// found the ending space or quote, so do everything _before_ that (need last position=p-1, which means a count of p)
+			wsSettingsDir = wsSettingsDir.substr(0, p);
+		}
+		else if (wsEnd == L"\"") {
+			// could not find end quote; should probably throw an error or something, but for now, just pretend I found nothing...
+			return L"";
+		}	// none found and looking for space means it found end-of-string, which is fine with the space separator
+	}
+
+	return wsSettingsDir;
+}

--- a/src/Classes/NppMetaClass.h
+++ b/src/Classes/NppMetaClass.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "PluginDefinition.h"
+#include "PopulateXSD.h"
+#include "pcjHelper.h"
+#include "menuCmdID.h"
+#include <string>
+
+class NppMetaInfo {
+public:
+	// constructor
+	NppMetaInfo(void);
+
+	// Run this in the constructor for any class that uses it
+	// (internally tracks whether it's been populated already, and doesn't duplicate effort)
+	void populate(void);
+
+	NppData& hwnd;
+
+	struct {
+		std::wstring
+			app,
+			appDataEquiv,
+			appThemes,
+			appExePath,
+			cfg,
+			cfgPluginConfig,
+			cfgPluginConfigMyDir,
+			cfgUdl,
+			cfgFunctionList,
+			cfgAutoCompletion,
+			cfgThemes;
+	} dir;
+
+private:
+	bool _isInitialized;
+	std::wstring _askSettingsDir(void);
+};
+
+// make sure everyone who can see this class can see the global instance
+extern NppMetaInfo gNppMetaInfo;

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -36,8 +36,14 @@ FuncItem funcItem[nbFunc];
 
 //
 // The data of Notepad++ that you can use in your plugin commands
+//      Pryrt note: this is automatically initialized by the plugin system
+//          but was not natively shared in PluginDefinition.h, so I added it
+//          (but not before I did `extern NppData nppData` in many places)
+//          But I'm going to try to incorporate it into a global instance
+//          of my NppMetaInfo object, to give me much more interesting info
 //
 NppData nppData;
+
 
 //
 // Initialize your plugin data here

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -85,7 +85,7 @@ extern NppData nppData;
 extern FuncItem funcItem[nbFunc];
 
 //
-// My global variables
+// My external global variables
 //
 
 extern HWND g_hwndAboutDlg;

--- a/src/pcjHelper.h
+++ b/src/pcjHelper.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <Windows.h>
 
 namespace pcjHelper
 {
@@ -12,5 +13,12 @@ namespace pcjHelper
 
 	// convert UTF8-encoded bytes in std::string to std::wstring
 	std::wstring utf8_to_wstring(std::string& str);
+
+	// recursively create all levels necessary for a given directory
+	BOOL RecursiveCreateDirectory(std::wstring wsPath);
+
+	// checks if a given directory is writeable
+	bool is_dir_writable(const std::wstring& path);
+
 };
 

--- a/vs.proj/ConfigUpdater.vcxproj
+++ b/vs.proj/ConfigUpdater.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="..\src\Classes\ConfigUpdaterClass.h" />
     <ClInclude Include="..\src\Classes\ConfigValidatorClass.h" />
     <ClInclude Include="..\src\Classes\HelloWorldClass.h" />
+    <ClInclude Include="..\src\Classes\NppMetaClass.h" />
     <ClInclude Include="..\src\Dialogs\AboutDialog.h" />
     <ClInclude Include="..\src\Dialogs\CUDownloadModelDialog.h" />
     <ClInclude Include="..\src\Dialogs\CUStatusDialog.h" />
@@ -61,6 +62,7 @@
     <ClCompile Include="..\src\Classes\ConfigDownloaderClass.cpp" />
     <ClCompile Include="..\src\Classes\ConfigUpdaterClass.cpp" />
     <ClCompile Include="..\src\Classes\ConfigValidatorClass.cpp" />
+    <ClCompile Include="..\src\Classes\NppMetaClass.cpp" />
     <ClCompile Include="..\src\Dialogs\AboutDialog.cpp" />
     <ClCompile Include="..\src\Dialogs\CUDownloadModelDialog.cpp" />
     <ClCompile Include="..\src\Dialogs\CUStatusDialog.cpp" />


### PR DESCRIPTION
Reason: D.R.Y. (Don't Repeat Yourself)
resolves #31

**Details**:

- New NppMetaInfo class
  - Have ConfigUpdaterClass, ConfigValidatorClass, and ConfigDownloaderClass all reference the new class, rather than using slightly different code which had to be independently maintained
- Move RecursiveCreateDirectory from PopulateXSD to pcjHelper
    - multiple classes referred to that, and it makes sense to put it in my helper
- Consolidate multiple _is_dir_writable() in various classes to a single version in pcjHelper
    - uses the RecursiveCreateDirectory which is now also in pcjHelper