### PR TITLE
v2.4: Add ability to Update Validators (XSD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ When Notepad++ updates, it tends to avoid updating important things like `langs.
 
 This plugin uses the `langs.model.xml` and `stylers.model.xml` which ship with every copy of Notepad++, and looks for any information that's in the model files, but not in your active config files.  It will copy over that missing information; when you then restart Notepad++, the syntax highlighting and keyword lists will have been updated to include all the settings in your current Notepad++ version.
 
+_NOTE_: Notepad++ v8.8.9 and newer automatically supplies missing styles, languages, and keyword lists from your model files, taking care of the primary feature of this plugin.  But this plugin still does it in bulk (even for inactive themes), and allows you to re-download your model files, and do manual file validation (which is useful when you are developing a new theme).
+
 ## Installation
 
 You can install the plugin using Notepad++'s **Plugins Admin**, or by unzipping the appropriate archive from the [latest release](https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/latest), so that `ConfigUpdater.dll` ends up in the `c:\Program Files\Notepad++\plugins\ConfigUpdater\` directory (or equivalent, for your installation's location).  (The files in the `docs\` folder from the zipfile could also be extracted into `c:\Program Files\Notepad++\plugins\ConfigUpdater\docs\` directory, but that's not required).
@@ -61,6 +63,12 @@ Historically, some of the themes have had XML problems, such as two styles in th
     - `'xyz' violates enumeration constraint of 'instre1 instre2 ...'
         - _Description_: The `name` for the `<Keywords>` entry for the given language must be one of the listed values: `instre1 instre2 type1 type2 type3 type4 type5 type6 type7 substyle1 substyle2 substyle3 substyle4 substyle5 substyle6 substyle7`.  It cannot be an empty string (so _not_ `name=""`), and it cannot be any other value that wasn't listed.
         - _Fix_: You need to set the `name` attribute to one of those values.  You can use **langs.model.xml** to compare the `<Keywords>` entry in the model that has the same entry in your XML, and see what name that `<Keywords>` element should have.
+
+### Reset Validators
+
+If the validators are complaining about an attribute or element that appears to be the same in the `*.model.xml` file, it may be that the XSD in the plugins config directory is out-of-date.  You can use **Plugins > ConfigUpdater > Update Validators** to delete the old copy, then you can rerun the manual validation or the download-and-validate, and see if that fixes the issue.
+
+If the `*.model.xml` file still has attributes or elements that the validator claims are wrong, you can go to https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/Test/xmlValidator and grab the newest copy of the `theme.xsd` and `langs.xsd`, and overwrite your `%AppData%\Notepad++\Plugins\Config\ConfigUpdater\*.xsd` files (or equivalent location, if using local configuration, Cloud Directory, or `-settingsDir`).  If this fixes the problem, please create an issue at https://github.com/pryrt/NppPlugin-ConfigUpdater/issues to ask that the XSD be updated (if there isn't already such an issue).
 
 ## Notes
 

--- a/src/Classes/ConfigUpdaterClass.cpp
+++ b/src/Classes/ConfigUpdaterClass.cpp
@@ -279,6 +279,21 @@ void ConfigUpdater::_initInternalState(void)
 	_initLangsValidatorXSD();
 }
 
+void ConfigUpdater::rewriteValidators(void)
+{
+	// make sure variables are set correctly
+	_initThemeValidatorXSD();
+	_initLangsValidatorXSD();
+
+	// delete the old copies
+	_deleteOldFileIfNeeded(_wsThemeValidatorXsdFileName);
+	_deleteOldFileIfNeeded(_wsLangsValidatorXsdFileName);
+
+	// create the new XSD files
+	_initThemeValidatorXSD();
+	_initLangsValidatorXSD();
+}
+
 // set the contents of the _bstr_ThemeValidatorXSD
 void ConfigUpdater::_initThemeValidatorXSD(void)
 {

--- a/src/Classes/ConfigUpdaterClass.h
+++ b/src/Classes/ConfigUpdaterClass.h
@@ -22,6 +22,7 @@ public:
 	ConfigUpdater(HWND hwndNpp);
 	bool go(bool isIntermediateSorted);
 	bool hadValidationError(void) { return _hadValidationError; };	// returns whether or not there was at least one validation error during the configuration update
+	void rewriteValidators(void);
 
 private:
 	// internal attributes

--- a/src/Dialogs/PluginVersion.h
+++ b/src/Dialogs/PluginVersion.h
@@ -18,8 +18,8 @@
 */
 
 #pragma once
-#define VERSION_DIGITALVALUE        2, 3, 0, 0
-#define VERSION_VALUE               "2.3.0\0"
+#define VERSION_DIGITALVALUE        2, 4, 0, 0
+#define VERSION_VALUE               "2.4.0\0"
 #define VERSION_WSTR                TEXT(VERSION_VALUE)
 #define VERSION_AUTHOR              "Peter C. Jones\0"
 #define VERSION_PLUGIN_DESCRIPTION  "Notepad++ Plugin to Keep Langs/Stylers/Themes Config Files Up-to-Date\0"

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -80,7 +80,9 @@ void commandMenuInit()
     setCommand(1, TEXT("Download Newest Model Files"), menucall_DownloadModelFiles, NULL, false);
     setCommand(2, TEXT("Validate Config Files"), menucall_ValidateConfigFiles , NULL, false);
     setCommand(3, TEXT(""), NULL, NULL, false);
-    setCommand(4, TEXT("About ConfigUpdater"), menucall_AboutDlg, NULL, false);
+    setCommand(4, TEXT("Reset Validators"), menucall_ResetValidators, NULL, false);
+    setCommand(5, TEXT(""), NULL, NULL, false);
+    setCommand(6, TEXT("About ConfigUpdater"), menucall_AboutDlg, NULL, false);
 }
 
 //
@@ -139,6 +141,12 @@ void menucall_ValidateConfigFiles(void)
 {
     // non-modal allows to still interact with the parent
     CreateDialogParam((HINSTANCE)_hModule, MAKEINTRESOURCE(IDD_CU_VALIDATION_DLG), nppData._nppHandle, (DLGPROC)ciDlgCUValidationProc, (LPARAM)NULL);
+}
+
+void menucall_ResetValidators(void)
+{
+    static ConfigUpdater oConf(nppData._nppHandle);
+    oConf.rewriteValidators();
 }
 
 void menucall_DownloadModelFiles(void)

--- a/src/PluginDefinition.h
+++ b/src/PluginDefinition.h
@@ -38,7 +38,7 @@ const TCHAR NPP_PLUGIN_NAME[] = TEXT("ConfigUpdater");
 //
 // Here define the number of your plugin commands
 //
-const int nbFunc = 5;
+const int nbFunc = 7;
 
 
 //
@@ -75,6 +75,7 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 void menucall_UpdateConfigFiles();
 void menucall_DownloadModelFiles();
 void menucall_ValidateConfigFiles();
+void menucall_ResetValidators();
 void menucall_AboutDlg();
 void buttoncall_ValidationHelpDlg();
 

--- a/src/PopulateXSD.cpp
+++ b/src/PopulateXSD.cpp
@@ -132,7 +132,6 @@ namespace PopulateXSD {
                   <xs:selector xpath="WordsStyle"/>
                   <xs:field xpath="@styleID" />
                 </xs:unique>
-
               </xs:element>
             </xs:sequence>
           </xs:complexType>
@@ -160,6 +159,7 @@ namespace PopulateXSD {
           </xs:unique>
         </xs:element>
       </xs:sequence>
+      <xs:attribute name="modelDate" type="xs:integer" use="optional"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>
@@ -230,6 +230,7 @@ namespace PopulateXSD {
           </xs:complexType>
         </xs:element>
       </xs:sequence>
+      <xs:attribute name="modelDate" type="xs:integer" use="optional"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>


### PR DESCRIPTION
XSD updated to allow optional modelDate attribute (to work with N++ v8.8.9)